### PR TITLE
Added support for binary and hex string key files.

### DIFF
--- a/KeePit/readkeyfile.h
+++ b/KeePit/readkeyfile.h
@@ -31,6 +31,7 @@ class ReadKeyFile
 public:
     ReadKeyFile();
     vector<char> read(char*, int) const;
+    vector<char> readHex(char*, int) const;
 };
 
 #endif // READKEYFILE_H


### PR DESCRIPTION
-These are common formats and are supported by keepass desktop.
-If XML parsing fails, we will attempt to use either binary or a hex string, depending on the file size.
